### PR TITLE
Enable i686

### DIFF
--- a/rust.spec
+++ b/rust.spec
@@ -35,6 +35,7 @@ BuildRequires:  perl
 BuildRequires:  curl
 #BuildRequires:  pandoc
 BuildRequires:  chrpath
+BuildRequires:  git
 %if %without bootstrap
 BuildRequires:  rust
 %endif
@@ -118,6 +119,7 @@ make check
 - Enable i686
 - Add bootstrap sources, so that build won't access Internet
 - Make it possible to build without bootstrapoing with bundled LLVM
+- BuildRequire git
 
 * Fri Apr 25 2014 Fabian Deutsch <fabiand@fedoraproject.org> - 0.10-1
 - Update to 0.10


### PR DESCRIPTION
Hi,

please consider pulling these commits. I've made some small adjustments to make it possible to build i686 in mock. Unfortunately, the tests don't seem to pass (even on x86_64), not sure why.

Here's build with make check skipped: http://koji.fedoraproject.org/koji/taskinfo?taskID=6824111
Failed tests: http://koji.fedoraproject.org/koji/taskinfo?taskID=6836696

Thank you!
Lubo
